### PR TITLE
Handle geo-referencing better

### DIFF
--- a/semantic_mesh_pytorch3d/config.py
+++ b/semantic_mesh_pytorch3d/config.py
@@ -12,15 +12,6 @@ DEFAULT_LOCAL_MESH = str(
     )
 )
 
-DEFAULT_GEOREF_MESH = str(
-    Path(
-        DATA_FOLDER,
-        "composite_georef",
-        "composite_georef.ply",
-    )
-)
-DEFAULT_GEOREF_MESH = "/ofo-share/repos-david/semantic-mesh-pytorch3d/data/2023-08-23_1027_QR_F1_rgb_100m_25_img/exports/2023-08-23_1027_QR_F1_rgb_100m_10_img_20230926T1520_model_georeferenced_manual_export.ply"
-
 DEFAULT_CAM_FILE = str(
     Path(
         DATA_FOLDER,
@@ -29,6 +20,11 @@ DEFAULT_CAM_FILE = str(
     )
 )
 
-DEFAULT_GEOFILE = str(
+DEFAULT_GEOPOLYGON_FILE = str(
     Path(DATA_FOLDER, "composite_20230520T0519", "composite_20230520T0519_crowns.gpkg")
 )
+
+COLORS = {
+    "canopy": [[34, 139, 34]],
+    "earth": [[175, 128, 79]],
+}

--- a/semantic_mesh_pytorch3d/config.py
+++ b/semantic_mesh_pytorch3d/config.py
@@ -19,6 +19,7 @@ DEFAULT_GEOREF_MESH = str(
         "composite_georef.ply",
     )
 )
+DEFAULT_GEOREF_MESH = "/ofo-share/repos-david/semantic-mesh-pytorch3d/data/2023-08-23_1027_QR_F1_rgb_100m_25_img/exports/2023-08-23_1027_QR_F1_rgb_100m_10_img_20230926T1520_model_georeferenced_manual_export.ply"
 
 DEFAULT_CAM_FILE = str(
     Path(


### PR DESCRIPTION
An important step is finding correspondences between the mesh and geo-referenced data such as polygons. Unfortunately, the mesh-to-image projections must be done in the arbitrary coordinate system defined by Metashape. Previously, I exported two meshes, one geospatial and one local, and used the hack that they had vertices in the same order. But now, I'm only using the local mesh and the local-to-EPGS:4978 transform contained in the cameras file.