### PR TITLE
Make IO more flexible

### DIFF
--- a/multiview_prediction_toolkit/segmentation/ortho_segmentor.py
+++ b/multiview_prediction_toolkit/segmentation/ortho_segmentor.py
@@ -13,6 +13,7 @@ from rastervision.core.evaluation import SemanticSegmentationEvaluator
 from rastervision.pytorch_learner import SemanticSegmentationSlidingWindowGeoDataset
 from tqdm import tqdm
 
+from multiview_prediction_toolkit.utils.io import read_image_or_numpy
 from multiview_prediction_toolkit.config import PATH_TYPE
 
 
@@ -237,7 +238,7 @@ class OrthoSegmentor:
         prediction_folder: PATH_TYPE,
         savefile: typing.Union[PATH_TYPE, None] = None,
         discard_edge_frac: float = 1 / 8,
-        eval_performance: bool = True,
+        eval_performance: bool = False,
         smooth_seg_labels: bool = False,
     ):
         """Take tiled predictions on disk and aggregate them into a raster
@@ -273,9 +274,8 @@ class OrthoSegmentor:
         for window, file in tqdm(
             zip(windows, files), total=len(windows), desc="Aggregating tile predictions"
         ):
-            # TODO make this support more filetypes
             # Load the data
-            pred = np.load(file)
+            pred = read_image_or_numpy(file)
 
             # This means the output is confidence-per-class, channel first
             if len(pred.shape) == 3:

--- a/multiview_prediction_toolkit/utils/io.py
+++ b/multiview_prediction_toolkit/utils/io.py
@@ -1,0 +1,35 @@
+import numpy as np
+from imageio import imread
+
+from multiview_prediction_toolkit.config import PATH_TYPE
+
+
+def read_image_or_numpy(filename: PATH_TYPE) -> np.ndarray:
+    """Read in a file that's either an image or numpy array
+
+    Args:
+        filename (PATH_TYPE): Filename to be read
+
+    Raises:
+        ValueError: If file cannot be read
+
+    Returns:
+        np.ndarray: Image, in format present on disk
+    """
+    img = None
+    if img is None:
+        try:
+            img = imread(filename)
+        except:
+            print("Couldn't read as image")
+
+    if img is None:
+        try:
+            img = np.load(filename)
+        except:
+            print("couldn't read as numpy")
+
+    if img is None:
+        raise ValueError("Could not read image")
+
+    return img


### PR DESCRIPTION
As we start to read and write more datatypes, we should move away from using IO methods of specific libraries directly. Specifically, we probably want to support using numpy and image saving interchangeably, depending just on the filename.  Move functionality into a separate module allows us to more easily standardize the IO format across the codebase and potentially make larger improvements such as doing IO in a different thread.