### PR TITLE
Replace rastervision with on-disk chip aggregation using rasterio

### DIFF
--- a/multiview_prediction_toolkit/entrypoints/orthomosaic_predictions.py
+++ b/multiview_prediction_toolkit/entrypoints/orthomosaic_predictions.py
@@ -69,10 +69,10 @@ def parse_args():
         help="Save aggregated predictions to this file. Must be writable by rasterio. Only used with --prediction-chips-folder",
     )
     parser.add_argument(
-        "--discard-edge-frac",
+        "--downweight-edge-frac",
         type=float,
-        default=0.125,
-        help="Discard this fraction of predictions at the edgest. Only used with --prediction-chips-folder",
+        default=0.25,
+        help="Downweight this fraction of predictions at the edges using a linear ramp. Only used with --prediction-chips-folder",
     )
     parser.add_argument(
         "--log-level",
@@ -126,6 +126,6 @@ if __name__ == "__main__":
         ortho_seg.assemble_tiled_predictions(
             args.prediction_chips_folder,
             savefile=args.aggregated_savefile,
-            discard_edge_frac=args.discard_edge_frac,
+            downweight_edge_frac=args.downweight_edge_frac,
             eval_performance=False,
         )

--- a/multiview_prediction_toolkit/utils/numeric.py
+++ b/multiview_prediction_toolkit/utils/numeric.py
@@ -1,0 +1,28 @@
+import typing
+
+import numpy as np
+
+
+def create_ramped_weighting(
+    rectangle_shape: typing.Tuple[int, int], ramp_dist_frac: float
+) -> np.ndarray:
+    """Create a ramped weighting that is higher toward the center with a max value of 1 at a fraction from the edge
+
+    Args:
+        rectangle_shape (typing.Tuple[int, int]): Size of rectangle to create a mask for
+        ramp_dist_frac (float): Portions at least this far from an edge will have full weight
+
+    Returns:
+        np.ndarray: An array representing the weighting from 0-1
+    """
+    i_ramp = np.clip(np.linspace(0, 1 / ramp_dist_frac, num=rectangle_shape[0]), 0, 1)
+    j_ramp = np.clip(np.linspace(0, 1 / ramp_dist_frac, num=rectangle_shape[1]), 0, 1)
+
+    i_ramp = np.minimum(i_ramp, np.flip(i_ramp))
+    j_ramp = np.minimum(j_ramp, np.flip(j_ramp))
+
+    i_ramp = np.expand_dims(i_ramp, 1)
+    j_ramp = np.expand_dims(j_ramp, 0)
+
+    ramped_weighting = np.minimum(i_ramp, j_ramp)
+    return ramped_weighting


### PR DESCRIPTION
We were having numerous issues with the aggregation approach for chipped predictions using `rastervision` including improper handling of ROIs and frequent OOM errors. I replaced this with a version using `rasterio` directly. This uses windowed read/writes so all bookkeeping is done on disk. This does require substantial temporary disk storage, but is generally more robust. 

I still need to do a bit of cleanup and documentation but this is now functional. 

On future improvement that I don't think needs to be addressed on this PR is to allow tiled predictions that are geospatially referenced, rather than requiring that they are referenced by pixel coordinates in the original raster. This should be fairly straightforward, but would require us to support resampling if the predictions are provided in a different CRS than the original raster.